### PR TITLE
added pack variants for tetra basic blade, short blade & basic pickaxe

### DIFF
--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -1,5 +1,38 @@
 {
 	"block.minecraft.nether_portal.name": "Nether Portal",
 	"block.kubejs.test_block": "My Awesome Block 9000",
-	"block.kubejs.bauxite_dirt_ore": "Bauxite Ore Deposit"
+	"block.kubejs.bauxite_dirt_ore": "Bauxite Ore Deposit",
+
+	"basic_blade/ruby": "Ruby blade",
+	"basic_blade/ruby.prefix": "Ruby",
+	"basic_blade/amethyst": "Amethyst blade",
+	"basic_blade/amethyst.prefix": "Amethyst",
+	"basic_blade/sapphire": "Sapphire blade",
+	"basic_blade/sapphire.prefix": "Sapphire",
+	"basic_blade/malachite": "Malachite blade",
+	"basic_blade/malachite.prefix": "Malachite",
+	"basic_blade/platinum": "Platinum blade",
+	"basic_blade/platinum.prefix": "Platinum",
+
+	"short_blade/ruby": "Ruby blade",
+	"short_blade/ruby.prefix": "Ruby",
+	"short_blade/amethyst": "Amethyst blade",
+	"short_blade/amethyst.prefix": "Amethyst",
+	"short_blade/sapphire": "Sapphire blade",
+	"short_blade/sapphire.prefix": "Sapphire",
+	"short_blade/malachite": "Malachite blade",
+	"short_blade/malachite.prefix": "Malachite",
+	"short_blade/platinum": "Platinum blade",
+	"short_blade/platinum.prefix": "Platinum",
+
+	"basic_pickaxe/ruby": "Ruby pick",
+	"basic_pickaxe/ruby.prefix": "Ruby",
+	"basic_pickaxe/amethyst": "Amethyst pick",
+	"basic_pickaxe/amethyst.prefix": "Amethyst",
+	"basic_pickaxe/sapphire": "Sapphire pick",
+	"basic_pickaxe/sapphire.prefix": "Sapphire",
+	"basic_pickaxe/malachite": "Malachite pick",
+	"basic_pickaxe/malachite.prefix": "Malachite",
+	"basic_pickaxe/platinum": "Platinum pick",
+	"basic_pickaxe/platinum.prefix": "Platinum"
 }

--- a/openloader/data/enigmatica/data/tetra/modules/duplex/basic_pickaxe.json
+++ b/openloader/data/enigmatica/data/tetra/modules/duplex/basic_pickaxe.json
@@ -1,0 +1,99 @@
+{
+	"variants": [
+		{
+			"key": "basic_pickaxe/ruby",
+			"durability": 365,
+			"integrity": -2,
+			"magicCapacity": 10,
+			"damage": 4,
+			"attackSpeed": -0.2,
+			"capabilities": {
+				"pickaxe": [4, 6.6667]
+			},
+			"glyph": {
+				"tint": "ff3859",
+				"textureX": 176
+			},
+			"models": [{
+				"location": "tetra:items/module/duplex/head/basic_pickaxe/metal",
+				"tint": "ff3859"
+			}]
+		},
+		{
+			"key": "basic_pickaxe/amethyst",
+			"durability": 365,
+			"integrity": -2,
+			"magicCapacity": 10,
+			"damage": 4,
+			"attackSpeed": -0.2,
+			"capabilities": {
+				"pickaxe": [4, 6.6667]
+			},
+			"glyph": {
+				"tint": "951cff",
+				"textureX": 176
+			},
+			"models": [{
+				"location": "tetra:items/module/duplex/head/basic_pickaxe/shiny",
+				"tint": "951cff"
+			}]
+		},
+		{
+			"key": "basic_pickaxe/sapphire",
+			"durability": 365,
+			"integrity": -2,
+			"magicCapacity": 10,
+			"damage": 4,
+			"attackSpeed": -0.2,
+			"capabilities": {
+				"pickaxe": [4, 6.6667]
+			},
+			"glyph": {
+				"tint": "383fff",
+				"textureX": 176
+			},
+			"models": [{
+				"location": "tetra:items/module/duplex/head/basic_pickaxe/metal",
+				"tint": "383fff"
+			}]
+		},
+		{
+			"key": "basic_pickaxe/malachite",
+			"durability": 365,
+			"integrity": -2,
+			"magicCapacity": 10,
+			"damage": 4,
+			"attackSpeed": -0.2,
+			"capabilities": {
+				"pickaxe": [4, 6.6667]
+			},
+			"glyph": {
+				"tint": "1fff96",
+				"textureX": 176
+			},
+			"models": [{
+				"location": "tetra:items/module/duplex/head/basic_pickaxe/metal",
+				"tint": "1fff96"
+			}]
+		},
+		{
+			"key": "basic_pickaxe/platinum",
+			"durability": 202,
+			"integrity": -2,
+			"magicCapacity": 11,
+			"damage": 2,
+			"attackSpeed": -0.2,
+			"capabilities": {
+				"pickaxe": [4, 6.5]
+			},
+			"glyph": {
+				"tint": "d6f6ff",
+				"textureX": 176
+			},
+			"models": [{
+				"location": "tetra:items/module/duplex/head/basic_pickaxe/metal",
+				"tint": "ccc2ff"
+			}]
+		}
+	]
+}

--- a/openloader/data/enigmatica/data/tetra/modules/sword/basic_blade.json
+++ b/openloader/data/enigmatica/data/tetra/modules/sword/basic_blade.json
@@ -1,21 +1,99 @@
-[
-    {
-        "key": "basic_blade/ruby",
-        "durability": 730,
-        "integrity": -2,
-        "magicCapacity": 10,
-        "damage": 5,
-        "attackSpeed": 1.65,
-        "effects": {
-            "sweeping": 1
-        },
-        "capabilities": {
-            "cut": [1, 0.9375]
-        },
-        "glyph": { "tint": "ff3859" },
-        "models": [{
-            "location": "tetra:items/module/sword/blade/basic/metal",
-            "tint": "ff3859"
-        }]
-    }
-]
+{
+	"variants": [
+		{
+			"key": "basic_blade/ruby",
+			"durability": 730,
+			"integrity": -2,
+			"magicCapacity": 10,
+			"damage": 5,
+			"attackSpeed": 0.2,
+			"effects": {
+				"sweeping": 1
+			},
+			"capabilities": {
+				"cut": [1, 0.9375]
+			},
+			"glyph": { "tint": "ff3859" },
+			"models": [{
+				"location": "tetra:items/module/sword/blade/basic/metal",
+				"tint": "ff3859"
+			}]
+		},
+		{
+			"key": "basic_blade/amethyst",
+			"durability": 730,
+			"integrity": -2,
+			"magicCapacity": 10,
+			"damage": 5,
+			"attackSpeed": 0.2,
+			"effects": {
+				"sweeping": 1
+			},
+			"capabilities": {
+				"cut": [1, 0.9375]
+			},
+			"glyph": { "tint": "951cff" },
+			"models": [{
+				"location": "tetra:items/module/sword/blade/basic/shiny",
+				"tint": "951cff"
+			}]
+		},
+		{
+			"key": "basic_blade/sapphire",
+			"durability": 730,
+			"integrity": -2,
+			"magicCapacity": 10,
+			"damage": 5,
+			"attackSpeed": 0.2,
+			"effects": {
+				"sweeping": 1
+			},
+			"capabilities": {
+				"cut": [1, 0.9375]
+			},
+			"glyph": { "tint": "383fff" },
+			"models": [{
+				"location": "tetra:items/module/sword/blade/basic/metal",
+				"tint": "383fff"
+			}]
+		},
+		{
+			"key": "basic_blade/malachite",
+			"durability": 730,
+			"integrity": -2,
+			"magicCapacity": 10,
+			"damage": 5,
+			"attackSpeed": 0.2,
+			"effects": {
+				"sweeping": 1
+			},
+			"capabilities": {
+				"cut": [1, 0.9375]
+			},
+			"glyph": { "tint": "1fff96" },
+			"models": [{
+				"location": "tetra:items/module/sword/blade/basic/metal",
+				"tint": "1fff96"
+			}]
+		},
+		{
+			"key": "basic_blade/platinum",
+			"durability": 380,
+			"integrity": -1,
+			"magicCapacity": 11,
+			"damage": 6,
+			"attackSpeed": 0.2,
+			"effects": {
+				"sweeping": 1
+			},
+			"capabilities": {
+				"cut": [1, 0.9375]
+			},
+			"glyph": { "tint": "d6f6ff" },
+			"models": [{
+				"location": "tetra:items/module/sword/blade/basic/metal",
+				"tint": "ccc2ff"
+			}]
+		}
+	]
+}

--- a/openloader/data/enigmatica/data/tetra/modules/sword/short_blade.json
+++ b/openloader/data/enigmatica/data/tetra/modules/sword/short_blade.json
@@ -1,0 +1,88 @@
+{
+	"variants": [
+		{
+			"key": "short_blade/ruby",
+			
+			"durability": 320,
+			"integrity": -2,
+			"magicCapacity": 10,
+			"damage": 6,
+			"attackSpeed": 1.5,
+			"capabilities": {
+				"cut": [1, 0.9375]
+			},
+			"glyph": { "tint": "ff3859" },
+			"models": [{
+				"location": "tetra:items/module/sword/blade/short/metal",
+				"tint": "ff3859"
+			}]
+		},
+		{
+			"key": "short_blade/amethyst",
+			
+			"durability": 320,
+			"integrity": -2,
+			"magicCapacity": 10,
+			"damage": 6,
+			"attackSpeed": 1.5,
+			"capabilities": {
+				"cut": [1, 0.9375]
+			},
+			"glyph": { "tint": "951cff" },
+			"models": [{
+				"location": "tetra:items/module/sword/blade/short/shiny",
+				"tint": "951cff"
+			}]
+		},
+		{
+			"key": "short_blade/sapphire",
+			
+			"durability": 320,
+			"integrity": -2,
+			"magicCapacity": 10,
+			"damage": 6,
+			"attackSpeed": 1.5,
+			"capabilities": {
+				"cut": [1, 0.9375]
+			},
+			"glyph": { "tint": "383fff" },
+			"models": [{
+				"location": "tetra:items/module/sword/blade/short/metal",
+				"tint": "383fff"
+			}]
+		},
+		{
+			"key": "short_blade/malachite",
+			
+			"durability": 320,
+			"integrity": -2,
+			"magicCapacity": 10,
+			"damage": 6,
+			"attackSpeed": 1.5,
+			"capabilities": {
+				"cut": [1, 0.9375]
+			},
+			"glyph": { "tint": "1fff96" },
+			"models": [{
+				"location": "tetra:items/module/sword/blade/short/metal",
+				"tint": "1fff96"
+			}]
+		},
+		{
+			"key": "short_blade/platinum",
+			"durability": 311,
+			"integrity": -1,
+			"magicCapacity": 11,
+			"damage": 5.5,
+			"attackSpeed": 1.5,
+			"capabilities": {
+				"cut": [1, 0.9375]
+			},
+			"glyph": { "tint": "d6f6ff" },
+			"models": [{
+				"location": "tetra:items/module/sword/blade/short/metal",
+				"tint": "ccc2ff"
+			}]
+		}
+	]
+}

--- a/openloader/data/enigmatica/data/tetra/replacements/enigmatica_pickaxe.json
+++ b/openloader/data/enigmatica/data/tetra/replacements/enigmatica_pickaxe.json
@@ -1,0 +1,121 @@
+[
+	{
+		"predicate": {
+			"item": "bluepower:ruby_pickaxe"
+		},
+		"item": "tetra:duplex_tool_modular",
+		"modules": {
+			"duplex/head_left": ["duplex/basic_pickaxe_left", "basic_pickaxe/ruby"],
+			"duplex/head_right": ["duplex/basic_pickaxe_right", "basic_pickaxe/ruby"],
+			"duplex/handle": ["duplex/basic_handle", "basic_handle/stick"]
+		},
+		"improvements": {
+			"duplex/head_left:arrested": 0,
+			"duplex/head_right:arrested": 0
+		}
+	},
+	{
+		"predicate": {
+			"item": "bluepower:amethyst_pickaxe"
+		},
+		"item": "tetra:duplex_tool_modular",
+		"modules": {
+			"duplex/head_left": ["duplex/basic_pickaxe_left", "basic_pickaxe/amethyst"],
+			"duplex/head_right": ["duplex/basic_pickaxe_right", "basic_pickaxe/amethyst"],
+			"duplex/handle": ["duplex/basic_handle", "basic_handle/stick"]
+		},
+		"improvements": {
+			"duplex/head_left:arrested": 0,
+			"duplex/head_right:arrested": 0
+		}
+	},
+	{
+		"predicate": {
+			"item": "bluepower:malachite_pickaxe"
+		},
+		"item": "tetra:duplex_tool_modular",
+		"modules": {
+			"duplex/head_left": ["duplex/basic_pickaxe_left", "basic_pickaxe/malachite"],
+			"duplex/head_right": ["duplex/basic_pickaxe_right", "basic_pickaxe/malachite"],
+			"duplex/handle": ["duplex/basic_handle", "basic_handle/stick"]
+		},
+		"improvements": {
+			"duplex/head_left:arrested": 0,
+			"duplex/head_right:arrested": 0
+		}
+	},
+	{
+		"predicate": {
+			"item": "bluepower:sapphire_pickaxe"
+		},
+		"item": "tetra:duplex_tool_modular",
+		"modules": {
+			"duplex/head_left": ["duplex/basic_pickaxe_left", "basic_pickaxe/sapphire"],
+			"duplex/head_right": ["duplex/basic_pickaxe_right", "basic_pickaxe/sapphire"],
+			"duplex/handle": ["duplex/basic_handle", "basic_handle/stick"]
+		},
+		"improvements": {
+			"duplex/head_left:arrested": 0,
+			"duplex/head_right:arrested": 0
+		}
+	},
+	{
+		"predicate": {
+			"item": "mysticalworld:amethyst_pickaxe"
+		},
+		"item": "tetra:duplex_tool_modular",
+		"modules": {
+			"duplex/head_left": ["duplex/basic_pickaxe_left", "basic_pickaxe/amethyst"],
+			"duplex/head_right": ["duplex/basic_pickaxe_right", "basic_pickaxe/amethyst"],
+			"duplex/handle": ["duplex/basic_handle", "basic_handle/stick"]
+		},
+		"improvements": {
+			"duplex/head_left:arrested": 0,
+			"duplex/head_right:arrested": 0
+		}
+	},
+	{
+		"predicate": {
+			"item": "mysticalworld:lead_pickaxe"
+		},
+		"item": "tetra:duplex_tool_modular",
+		"modules": {
+			"duplex/head_left": ["duplex/basic_pickaxe_left", "basic_pickaxe/lead"],
+			"duplex/head_right": ["duplex/basic_pickaxe_right", "basic_pickaxe/lead"],
+			"duplex/handle": ["duplex/basic_handle", "basic_handle/stick"]
+		}
+	},
+	{
+		"predicate": {
+			"item": "mysticalworld:tin_pickaxe"
+		},
+		"item": "tetra:duplex_tool_modular",
+		"modules": {
+			"duplex/head_left": ["duplex/basic_pickaxe_left", "basic_pickaxe/tin"],
+			"duplex/head_right": ["duplex/basic_pickaxe_right", "basic_pickaxe/tin"],
+			"duplex/handle": ["duplex/basic_handle", "basic_handle/stick"]
+		}
+	},
+	{
+		"predicate": {
+			"item": "mysticalworld:copper_pickaxe"
+		},
+		"item": "tetra:duplex_tool_modular",
+		"modules": {
+			"duplex/head_left": ["duplex/basic_pickaxe_left", "basic_pickaxe/copper"],
+			"duplex/head_right": ["duplex/basic_pickaxe_right", "basic_pickaxe/copper"],
+			"duplex/handle": ["duplex/basic_handle", "basic_handle/stick"]
+		}
+	},
+	{
+		"predicate": {
+			"item": "mysticalworld:silver_pickaxe"
+		},
+		"item": "tetra:duplex_tool_modular",
+		"modules": {
+			"duplex/head_left": ["duplex/basic_pickaxe_left", "basic_pickaxe/silver"],
+			"duplex/head_right": ["duplex/basic_pickaxe_right", "basic_pickaxe/silver"],
+			"duplex/handle": ["duplex/basic_handle", "basic_handle/stick"]
+		}
+	}
+]

--- a/openloader/data/enigmatica/data/tetra/replacements/enigmatica_sword.json
+++ b/openloader/data/enigmatica/data/tetra/replacements/enigmatica_sword.json
@@ -1,17 +1,125 @@
 [
-    {
-        "predicate": {
-            "item": "bluepower:ruby_sword"
-        },
-        "item": "tetra:sword_modular",
-        "modules": {
-            "sword/blade": ["sword/basic_blade", "basic_blade/ruby"],
-            "sword/hilt": ["sword/basic_hilt", "basic_hilt/stick"],
-            "sword/pommel": ["sword/decorative_pommel", "decorative_pommel/oak"],
-            "sword/guard": ["sword/makeshift_guard", "makeshift_guard/oak"]
-        },
-        "improvements": {
-            "sword/blade:arrested": 0
-        }
-    }
+	{
+		"predicate": {
+			"item": "bluepower:ruby_sword"
+		},
+		"item": "tetra:sword_modular",
+		"modules": {
+			"sword/blade": ["sword/basic_blade", "basic_blade/ruby"],
+			"sword/hilt": ["sword/basic_hilt", "basic_hilt/stick"],
+			"sword/pommel": ["sword/decorative_pommel", "decorative_pommel/oak"],
+			"sword/guard": ["sword/makeshift_guard", "makeshift_guard/oak"]
+		},
+		"improvements": {
+			"sword/blade:arrested": 0
+		}
+	},
+	{
+		"predicate": {
+			"item": "bluepower:amethyst_sword"
+		},
+		"item": "tetra:sword_modular",
+		"modules": {
+			"sword/blade": ["sword/basic_blade", "basic_blade/amethyst"],
+			"sword/hilt": ["sword/basic_hilt", "basic_hilt/stick"],
+			"sword/pommel": ["sword/decorative_pommel", "decorative_pommel/oak"],
+			"sword/guard": ["sword/makeshift_guard", "makeshift_guard/oak"]
+		},
+		"improvements": {
+			"sword/blade:arrested": 0
+		}
+	},
+	{
+		"predicate": {
+			"item": "bluepower:malachite_sword"
+		},
+		"item": "tetra:sword_modular",
+		"modules": {
+			"sword/blade": ["sword/basic_blade", "basic_blade/malachite"],
+			"sword/hilt": ["sword/basic_hilt", "basic_hilt/stick"],
+			"sword/pommel": ["sword/decorative_pommel", "decorative_pommel/oak"],
+			"sword/guard": ["sword/makeshift_guard", "makeshift_guard/oak"]
+		},
+		"improvements": {
+			"sword/blade:arrested": 0
+		}
+	},
+	{
+		"predicate": {
+			"item": "bluepower:sapphire_sword"
+		},
+		"item": "tetra:sword_modular",
+		"modules": {
+			"sword/blade": ["sword/basic_blade", "basic_blade/sapphire"],
+			"sword/hilt": ["sword/basic_hilt", "basic_hilt/stick"],
+			"sword/pommel": ["sword/decorative_pommel", "decorative_pommel/oak"],
+			"sword/guard": ["sword/makeshift_guard", "makeshift_guard/oak"]
+		},
+		"improvements": {
+			"sword/blade:arrested": 0
+		}
+	},
+	{
+		"predicate": {
+			"item": "mysticalworld:amethyst_sword"
+		},
+		"item": "tetra:sword_modular",
+		"modules": {
+			"sword/blade": ["sword/basic_blade", "basic_blade/amethyst"],
+			"sword/hilt": ["sword/basic_hilt", "basic_hilt/stick"],
+			"sword/pommel": ["sword/decorative_pommel", "decorative_pommel/oak"],
+			"sword/guard": ["sword/makeshift_guard", "makeshift_guard/oak"]
+		},
+		"improvements": {
+			"sword/blade:arrested": 0
+		}
+	},
+	{
+		"predicate": {
+			"item": "mysticalworld:lead_sword"
+		},
+		"item": "tetra:sword_modular",
+		"modules": {
+			"sword/blade": ["sword/basic_blade", "basic_blade/lead"],
+			"sword/hilt": ["sword/basic_hilt", "basic_hilt/stick"],
+			"sword/pommel": ["sword/decorative_pommel", "decorative_pommel/oak"],
+			"sword/guard": ["sword/makeshift_guard", "makeshift_guard/oak"]
+		}
+	},
+	{
+		"predicate": {
+			"item": "mysticalworld:tin_sword"
+		},
+		"item": "tetra:sword_modular",
+		"modules": {
+			"sword/blade": ["sword/basic_blade", "basic_blade/tin"],
+			"sword/hilt": ["sword/basic_hilt", "basic_hilt/stick"],
+			"sword/pommel": ["sword/decorative_pommel", "decorative_pommel/oak"],
+			"sword/guard": ["sword/makeshift_guard", "makeshift_guard/oak"]
+		}
+	},
+	{
+		"predicate": {
+			"item": "mysticalworld:copper_sword"
+		},
+		"item": "tetra:sword_modular",
+		"modules": {
+			"sword/blade": ["sword/basic_blade", "basic_blade/copper"],
+			"sword/hilt": ["sword/basic_hilt", "basic_hilt/stick"],
+			"sword/pommel": ["sword/decorative_pommel", "decorative_pommel/oak"],
+			"sword/guard": ["sword/makeshift_guard", "makeshift_guard/oak"]
+		}
+	},
+	{
+		"predicate": {
+			"item": "mysticalworld:silver_sword"
+		},
+		"item": "tetra:sword_modular",
+		"modules": {
+			"sword/blade": ["sword/basic_blade", "basic_blade/silver"],
+			"sword/hilt": ["sword/basic_hilt", "basic_hilt/stick"],
+			"sword/pommel": ["sword/decorative_pommel", "decorative_pommel/oak"],
+			"sword/guard": ["sword/makeshift_guard", "makeshift_guard/oak"]
+		}
+	}
 ]

--- a/openloader/data/enigmatica/data/tetra/schemas/duplex/basic_pickaxe/basic_pickaxe.json
+++ b/openloader/data/enigmatica/data/tetra/schemas/duplex/basic_pickaxe/basic_pickaxe.json
@@ -8,8 +8,8 @@
 			"requiredCapabilities": {
 				"hammer": 1
 			},
-			"moduleKey": "sword/basic_blade",
-			"moduleVariant": "basic_blade/ruby",
+			"moduleKey": "duplex/basic_pickaxe",
+			"moduleVariant": "basic_pickaxe/ruby",
 			"improvements": {
 				"arrested": 0
 			}
@@ -22,8 +22,8 @@
 			"requiredCapabilities": {
 				"hammer": 1
 			},
-			"moduleKey": "sword/basic_blade",
-			"moduleVariant": "basic_blade/amethyst",
+			"moduleKey": "duplex/basic_pickaxe",
+			"moduleVariant": "basic_pickaxe/amethyst",
 			"improvements": {
 				"arrested": 0
 			}
@@ -36,8 +36,8 @@
 			"requiredCapabilities": {
 				"hammer": 1
 			},
-			"moduleKey": "sword/basic_blade",
-			"moduleVariant": "basic_blade/sapphire",
+			"moduleKey": "duplex/basic_pickaxe",
+			"moduleVariant": "basic_pickaxe/sapphire",
 			"improvements": {
 				"arrested": 0
 			}
@@ -50,8 +50,8 @@
 			"requiredCapabilities": {
 				"hammer": 1
 			},
-			"moduleKey": "sword/basic_blade",
-			"moduleVariant": "basic_blade/malachite",
+			"moduleKey": "duplex/basic_pickaxe",
+			"moduleVariant": "basic_pickaxe/malachite",
 			"improvements": {
 				"arrested": 0
 			}
@@ -64,8 +64,8 @@
 			"requiredCapabilities": {
 				"hammer": 2
 			},
-			"moduleKey": "sword/basic_blade",
-			"moduleVariant": "basic_blade/platinum"
+			"moduleKey": "duplex/basic_pickaxe",
+			"moduleVariant": "basic_pickaxe/platinum"
 		}
 	]
 }

--- a/openloader/data/enigmatica/data/tetra/schemas/sword/short_blade.json
+++ b/openloader/data/enigmatica/data/tetra/schemas/sword/short_blade.json
@@ -1,0 +1,66 @@
+{
+	"outcomes": [
+		{
+			"material": {
+				"tag": "forge:gems/ruby"
+			},
+			"requiredCapabilities": {
+				"hammer": 3
+			},
+			"moduleKey": "sword/short_blade",
+			"moduleVariant": "short_blade/ruby",
+			"improvements": {
+				"arrested": 0
+			}
+		},
+		{
+			"material": {
+				"tag": "forge:gems/amethyst"
+			},
+			"requiredCapabilities": {
+				"hammer": 3
+			},
+			"moduleKey": "sword/short_blade",
+			"moduleVariant": "short_blade/amethyst",
+			"improvements": {
+				"arrested": 0
+			}
+		},
+		{
+			"material": {
+				"tag": "forge:gems/sapphire"
+			},
+			"requiredCapabilities": {
+				"hammer": 3
+			},
+			"moduleKey": "sword/short_blade",
+			"moduleVariant": "short_blade/sapphire",
+			"improvements": {
+				"arrested": 0
+			}
+		},
+		{
+			"material": {
+				"tag": "forge:gems/malachite"
+			},
+			"requiredCapabilities": {
+				"hammer": 3
+			},
+			"moduleKey": "sword/short_blade",
+			"moduleVariant": "short_blade/malachite",
+			"improvements": {
+				"arrested": 0
+			}
+		},
+		{
+			"material": {
+				"tag": "forge:ingots/platinum"
+			},
+			"requiredCapabilities": {
+				"hammer": 3
+			},
+			"moduleKey": "sword/short_blade",
+			"moduleVariant": "short_blade/platinum"
+		}
+	]
+}

--- a/openloader/data/enigmatica/data/tetra/synergies/enigmatica_duplex.json
+++ b/openloader/data/enigmatica/data/tetra/synergies/enigmatica_duplex.json
@@ -1,0 +1,8 @@
+[
+	{
+		"moduleVariants": ["basic_pickaxe/platinum", "basic_pickaxe/platinum"],
+		"capabilities": {
+			"pickaxe": 1
+		}
+	}
+]


### PR DESCRIPTION
The damage & durability of tin, copper & lead variants of swords does not align with mysticalworld, the dmage & durability is an average based on several 1.12 mods. Should I update those damage & durability for those to be the same as in mysticalworld?