### PR TITLE
Removed carriage returns

### DIFF
--- a/development/include-in-server-files/server-start.sh
+++ b/development/include-in-server-files/server-start.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 #### Minecraft-Forge Server install/launcher script
 #### Linux Version
 ####


### PR DESCRIPTION
I wonder if Git just doesn't track carriage returns properly, since I see no other changes. But this version at least runs with bash.