### PR TITLE
Separated the config into another _linux version for bash/zsh etc

### DIFF
--- a/development/include-in-server-files/server-start.sh
+++ b/development/include-in-server-files/server-start.sh
@@ -208,7 +208,7 @@ read_config(){
       			eval "export ${name}='${val%?}'"
       		fi
    		fi
-	done < settings.cfg 
+	done < settings_linux.cfg 
 
 }
 

--- a/development/include-in-server-files/settings_linux.cfg
+++ b/development/include-in-server-files/settings_linux.cfg
@@ -1,0 +1,19 @@
+;SETTINGS FOR SERVERSTART SCRIPTS
+;See "serverstart.log" in the LOGS subfolder 
+;For more details/help see: https://github.com/AllTheMods/Server-Scripts
+
+MAX_RAM=8G
+JAVA_ARGS=-d64 -server -XX:+AggressiveOpts -XX:+UseConcMarkSweepGC -XX:+UnlockExperimentalVMOptions -XX:+UseParNewGC -XX:+ExplicitGCInvokesConcurrent -XX:+UseFastAccessorMethods -XX:+OptimizeStringConcat -XX:+UseAdaptiveGCBoundary
+CRASH_COUNT=5
+CRASH_TIMER=600
+RUN_FROM_BAD_FOLDER=0 
+IGNORE_OFFLINE=0
+IGNORE_JAVA_CHECK=0
+USE_SPONGE=0
+HIGH_CPU_PRIORITY=0
+
+MODPACK_NAME=Enigmatica 4
+MCVER=1.14.4
+FORGEVER=28.1.109
+FORGEURL=https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.14.4-28.1.109/forge-1.14.4-28.1.109-installer.jar
+


### PR DESCRIPTION
This resolves #290 . Bash (and presumably zsh) do not use semicolons in variable names. Now the server scripts should work in Mac and Linux -type systems.

Along with the previous pull request I made, it also resolves #289 